### PR TITLE
fix: pass explicit GitHub token env to opencode workflows

### DIFF
--- a/.github/workflows/ai-implement.yml
+++ b/.github/workflows/ai-implement.yml
@@ -42,6 +42,8 @@ jobs:
           MODEL: opencode/big-pickle
           AGENT: implementer
           SKAINET_TOKEN: ${{ secrets.SKAINET_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         run: opencode github run
 
       - name: Label created PR as ai-implemented

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -40,6 +40,8 @@ jobs:
         env:
           MODEL: opencode/big-pickle
           AGENT: reviewer
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           PROMPT: |
             Review this pull request thoroughly:
             - Check for code quality issues, potential bugs, and security concerns

--- a/.github/workflows/ai-rework.yml
+++ b/.github/workflows/ai-rework.yml
@@ -45,6 +45,8 @@ jobs:
         env:
           MODEL: opencode/big-pickle
           AGENT: reworker
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           PROMPT: |
             Address all review comments on this pull request.
             Read each comment carefully and implement the requested changes.

--- a/docs/agentic-pipeline/adoption-baseline.md
+++ b/docs/agentic-pipeline/adoption-baseline.md
@@ -13,3 +13,15 @@ Canonical source followed: `ai-agents-pipeline/docs/agents/adopting-in-another-r
 | Copy `mise.toml` and `lefthook.yml` | Copied both files into Excalidraw root | Pass |
 | Run `mise install` | Tools installed and validated with `actionlint` | Pass |
 | Hook wiring for existing Husky repo | Kept Husky as owner and invoked Lefthook via `.husky/pre-commit` | Pass |
+
+## Post-setup deviation applied for runtime compatibility
+
+- Deviation: Added explicit `GITHUB_TOKEN` and `GH_TOKEN` (from `PERSONAL_ACCESS_TOKEN`) to `opencode github run` steps in:
+  - `.github/workflows/ai-implement.yml`
+  - `.github/workflows/ai-review.yml`
+  - `.github/workflows/ai-rework.yml`
+- Reason: First live smoke test run failed in implement stage with:
+  - `undefined is not an object (evaluating 'octoRest.rest')`
+- Validation plan:
+  - Re-run `/oc implement` issue trigger after merging this workflow fix.
+  - Confirm implement run can progress beyond OpenCode invocation and create a PR.


### PR DESCRIPTION
## Summary

Fixes runtime failure in `opencode github run` observed during live smoke test by providing explicit GitHub token env vars to AI workflows.

## Changes

- Added `GITHUB_TOKEN` and `GH_TOKEN` (sourced from `PERSONAL_ACCESS_TOKEN`) in:
  - `.github/workflows/ai-implement.yml`
  - `.github/workflows/ai-review.yml`
  - `.github/workflows/ai-rework.yml`
- Documented this deviation in:
  - `docs/agentic-pipeline/adoption-baseline.md`

## Context

Initial run failed in implement stage with:
`undefined is not an object (evaluating 'octoRest.rest')`

This PR applies the minimal compatibility fix so the pipeline can be tested end-to-end.
