### PR TITLE
fix: run opencode github install before github run

### DIFF
--- a/.github/workflows/ai-implement.yml
+++ b/.github/workflows/ai-implement.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Add OpenCode to PATH
         run: echo "$HOME/.opencode/bin" >> $GITHUB_PATH
 
+      - name: Install OpenCode GitHub agent
+        run: opencode github install
+
       - name: Run OpenCode implementer agent
         env:
           MODEL: opencode/big-pickle

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Add OpenCode to PATH
         run: echo "$HOME/.opencode/bin" >> $GITHUB_PATH
 
+      - name: Install OpenCode GitHub agent
+        run: opencode github install
+
       - name: Run OpenCode reviewer agent
         env:
           MODEL: opencode/big-pickle

--- a/.github/workflows/ai-rework.yml
+++ b/.github/workflows/ai-rework.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Add OpenCode to PATH
         run: echo "$HOME/.opencode/bin" >> $GITHUB_PATH
 
+      - name: Install OpenCode GitHub agent
+        run: opencode github install
+
       - name: Run OpenCode reworker agent
         env:
           MODEL: opencode/big-pickle

--- a/docs/agentic-pipeline/adoption-baseline.md
+++ b/docs/agentic-pipeline/adoption-baseline.md
@@ -25,3 +25,11 @@ Canonical source followed: `ai-agents-pipeline/docs/agents/adopting-in-another-r
 - Validation plan:
   - Re-run `/oc implement` issue trigger after merging this workflow fix.
   - Confirm implement run can progress beyond OpenCode invocation and create a PR.
+
+## Additional runtime deviation under test
+
+- Deviation: Added `opencode github install` before `opencode github run` in all three AI workflows.
+- Reason: `opencode` exposes separate `github install` and `github run` commands; repeated implement failures suggest GitHub agent bootstrap may be missing on clean runners.
+- Validation plan:
+  - Re-run `/oc implement` after merging this change.
+  - Confirm implement stage no longer fails with `octoRest.rest` error.


### PR DESCRIPTION
## Summary

Adds `opencode github install` before `opencode github run` in all AI workflows to bootstrap GitHub agent state on clean runners.

## Changes

- `.github/workflows/ai-implement.yml`
- `.github/workflows/ai-review.yml`
- `.github/workflows/ai-rework.yml`
  - Added step: `Install OpenCode GitHub agent` (`opencode github install`)

- `docs/agentic-pipeline/adoption-baseline.md`
  - Recorded this runtime deviation and validation plan.

## Why

Live smoke tests still failed in implement stage with:
`undefined is not an object (evaluating 'octoRest.rest')`

Given OpenCode CLI exposes distinct `github install` and `github run` commands, this patch ensures explicit bootstrap before runtime.
