### PR TITLE
fix: remove interactive opencode install step from workflows

### DIFF
--- a/.github/workflows/ai-implement.yml
+++ b/.github/workflows/ai-implement.yml
@@ -37,9 +37,6 @@ jobs:
       - name: Add OpenCode to PATH
         run: echo "$HOME/.opencode/bin" >> $GITHUB_PATH
 
-      - name: Install OpenCode GitHub agent
-        run: opencode github install
-
       - name: Run OpenCode implementer agent
         env:
           MODEL: opencode/big-pickle

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -36,9 +36,6 @@ jobs:
       - name: Add OpenCode to PATH
         run: echo "$HOME/.opencode/bin" >> $GITHUB_PATH
 
-      - name: Install OpenCode GitHub agent
-        run: opencode github install
-
       - name: Run OpenCode reviewer agent
         env:
           MODEL: opencode/big-pickle

--- a/.github/workflows/ai-rework.yml
+++ b/.github/workflows/ai-rework.yml
@@ -41,9 +41,6 @@ jobs:
       - name: Add OpenCode to PATH
         run: echo "$HOME/.opencode/bin" >> $GITHUB_PATH
 
-      - name: Install OpenCode GitHub agent
-        run: opencode github install
-
       - name: Run OpenCode reworker agent
         env:
           MODEL: opencode/big-pickle

--- a/docs/agentic-pipeline/adoption-baseline.md
+++ b/docs/agentic-pipeline/adoption-baseline.md
@@ -26,10 +26,13 @@ Canonical source followed: `ai-agents-pipeline/docs/agents/adopting-in-another-r
   - Re-run `/oc implement` issue trigger after merging this workflow fix.
   - Confirm implement run can progress beyond OpenCode invocation and create a PR.
 
-## Additional runtime deviation under test
+## Additional runtime deviation tested and reverted
 
-- Deviation: Added `opencode github install` before `opencode github run` in all three AI workflows.
-- Reason: `opencode` exposes separate `github install` and `github run` commands; repeated implement failures suggest GitHub agent bootstrap may be missing on clean runners.
-- Validation plan:
-  - Re-run `/oc implement` after merging this change.
-  - Confirm implement stage no longer fails with `octoRest.rest` error.
+- Tested deviation: Added `opencode github install` before `opencode github run` in all three AI workflows.
+- Reason for test: `opencode` exposes separate `github install` and `github run` commands.
+- Validation result:
+  - In GitHub Actions, `opencode github install` entered an interactive app-install flow and blocked/fails in CI.
+  - Error observed: `Failed to detect GitHub app installation. Make sure to install the app for the 'NoRiceToday/excalidraw' repository.`
+- Decision:
+  - Reverted `opencode github install` from workflows.
+  - Keep app installation as a manual prerequisite outside CI.


### PR DESCRIPTION
## Summary

Reverts the `opencode github install` step from CI workflows because it is interactive and blocks/fails in GitHub Actions.

## Why

During live smoke tests, this step entered an app-install flow and did not behave as a CI-safe non-interactive command.

## Changes

- Removed `opencode github install` from:
  - `.github/workflows/ai-implement.yml`
  - `.github/workflows/ai-review.yml`
  - `.github/workflows/ai-rework.yml`
- Updated `docs/agentic-pipeline/adoption-baseline.md` with tested-and-reverted deviation notes.

## Notes

OpenCode app installation remains a manual prerequisite outside CI.
